### PR TITLE
fix: added support for query helper template tag - resolves #1

### DIFF
--- a/syntaxes/inline-aql.json
+++ b/syntaxes/inline-aql.json
@@ -18,7 +18,7 @@
   },
   "patterns": [
     {
-      "begin": "(([^(])?(aql|AQL))(`)",
+      "begin": "(([^(])?(aql|AQL|query))(`)",
       "end": "(`)",
       "beginCaptures": {
         "1": {

--- a/test/test.js
+++ b/test/test.js
@@ -53,3 +53,13 @@ const testQuery4 = /*aql*/`
     FILTER GEO_INTERSECTS(someAreaInNYC, n.geometry)
     RETURN n.geometry
 `;
+
+const testQuery5 = query`
+  FOR user IN users
+    FILTER user.active == 1
+    RETURN {
+      name: CONCAT(user.firstName, " ",
+                  user.lastName),
+      gender: user.gender
+    }
+`;


### PR DESCRIPTION
Allow template tag support for ArangoDB's query helper: https://www.arangodb.com/docs/stable/appendix-java-script-modules-arango-db.html

Also includes a test query (taken from [sql/aql comparison](https://www.arangodb.com/why-arangodb/sql-aql-comparison/)) with the new template tag.